### PR TITLE
Coverage measurement and tests for getEnvColor and extractCoordinates

### DIFF
--- a/src/config/themes/default/defaultTheme.js
+++ b/src/config/themes/default/defaultTheme.js
@@ -13,7 +13,9 @@ See the Licence for the specific language governing permissions and
 limitations under the Licence. */
 
 import { fade } from "material-ui/utils/colorManipulator";
+import { markBranchHit } from "../../../test/instrumentation/coverageData";
 import { getTiamatEnv } from "../../themeConfig";
+
 
 export const primary = "#5AC39A";
 export const primaryDarker = "#181C56";
@@ -31,12 +33,16 @@ export const getEnvColor = (env) => {
   let currentEnv = env || getTiamatEnv();
   switch (currentEnv.toLowerCase()) {
     case "development":
+      markBranchHit("getEnvColor", 0);
       return "#457645";
     case "test":
+      markBranchHit("getEnvColor", 1);
       return "#d18e25";
     case "prod":
+      markBranchHit("getEnvColor", 2);
       return darkColor;
     default:
+      markBranchHit("getEnvColor", 3);
       return darkColor;
   }
 };

--- a/src/test/config/themes/default/defaultTheme.spec.js
+++ b/src/test/config/themes/default/defaultTheme.spec.js
@@ -1,0 +1,29 @@
+import { getTiamatEnv } from '../../../../config/themeConfig';
+import {getEnvColor, darkColor} from '../../../../config/themes/default/defaultTheme';
+
+describe('getEnvColor', () => {
+    test('Development env should be #457645', () => {
+        const env = "development";
+        expect(getEnvColor(env)).toEqual("#457645");
+    });
+
+    test('Test env should be #d18e25', () => {
+        const env = "test";
+        expect(getEnvColor(env)).toEqual("#d18e25");
+    });
+
+    test('Prod env should be darkColor', () => {
+        const env = "prod";
+        expect(getEnvColor(env)).toEqual(darkColor);
+    });
+
+    test('Any other env should be darkColor', () => {
+        const env = "foo";
+        expect(getEnvColor(env)).toEqual(darkColor);
+    });
+
+    test('Empty env should be the same as tiamatEnv', () => {
+        const env = null;
+        expect(getEnvColor(env)).toEqual(getEnvColor(getTiamatEnv()));
+    });
+});

--- a/src/test/extractors.spec.js
+++ b/src/test/extractors.spec.js
@@ -33,4 +33,18 @@ describe("extractors", () => {
 
     expect(latLngFromTab).toEqual(latLngExpected);
   });
+
+  test("should return null if the provided latlng string is invalid", () => {
+    const latLngFromNull = extractCoordinates(null);
+    expect(latLngFromNull).toEqual(null);
+
+    const latLngFromOneNum = extractCoordinates("123");
+    expect(latLngFromOneNum).toEqual(null);
+
+    const latLngFromNaN = extractCoordinates("abc def");
+    expect(latLngFromNaN).toEqual(null);
+
+    const latLngFromMultipleNums = extractCoordinates("123, 456,  789");
+    expect(latLngFromMultipleNums).toEqual(null);
+  });
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,6 +13,7 @@ See the Licence for the specific language governing permissions and
 limitations under the Licence. */
 
 import moment from "moment";
+import { markBranchHit } from "../test/instrumentation/coverageData";
 
 export const setDecimalPrecision = (number, n) => {
   if (isNaN(number) || isNaN(n)) {
@@ -50,20 +51,27 @@ export const getCoordinatesFromGeometry = (geometry) => {
 };
 
 export const extractCoordinates = (latLngString) => {
-  if (!latLngString) return null;
+  if (!latLngString) {
+    markBranchHit("extractCoordinates", 0);
+    return null;
+  }
 
   let coords = null;
 
   if (latLngString.indexOf(",") > 1) {
+    markBranchHit("extractCoordinates", 1);
     coords = latLngString.split(",");
   } else {
+    markBranchHit("extractCoordinates", 2);
     coords = latLngString.split(/\s*[\s,]\s*/);
   }
 
   if (coords && coords.length === 2 && !isNaN(coords[0]) && !isNaN(coords[1])) {
+    markBranchHit("extractCoordinates", 3);
     const result = coords.map((c) => setDecimalPrecision(c, 6));
     return result;
   }
+  markBranchHit("extractCoordinates", 4);
   return null;
 };
 


### PR DESCRIPTION
`getEnvColor` of `src/config/themes/default/defaultTheme.js`
`extractCoordinates` of `src/utils/index.js`