### PR TITLE
Snackbar & Selectors Unit Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 tmp/
 
 .firebase/
+src/test/instrumentation/coverageState.json

--- a/src/reducers/selectors.js
+++ b/src/reducers/selectors.js
@@ -12,18 +12,28 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the Licence for the specific language governing permissions and
 limitations under the Licence. */
 
+import { markBranchHit } from "../test/instrumentation/coverageData";
+
+
 export const selectKeyValuesDataSource = (keyValuesOrigin, stopPlace) => {
-  if (!keyValuesOrigin || !keyValuesOrigin.type) return [];
+  if (!keyValuesOrigin || !keyValuesOrigin.type) {
+    markBranchHit("selectKeyValuesDataSource", 0);
+    return []
+  };
 
   let keyValues = [];
 
   if (keyValuesOrigin.type === "stopPlace") {
+    markBranchHit("selectKeyValuesDataSource", 1);
     keyValues = stopPlace.keyValues;
   } else if (keyValuesOrigin.type === "quay") {
+    markBranchHit("selectKeyValuesDataSource", 2);
     let quay = stopPlace.quays[keyValuesOrigin.index];
     if (quay) {
+      markBranchHit("selectKeyValuesDataSource", 3);
       keyValues = stopPlace.quays[keyValuesOrigin.index].keyValues;
     }
   }
+  markBranchHit("selectKeyValuesDataSource", 4);
   return keyValues;
 };

--- a/src/reducers/snackbarReducer.js
+++ b/src/reducers/snackbarReducer.js
@@ -18,6 +18,7 @@ import {
   OPENED_SNACKBAR,
   DISMISSED_SNACKBAR,
 } from "../actions/Types";
+import { markBranchHit } from "../test/instrumentation/coverageData";
 
 export const initialState = {
   snackbarOptions: {
@@ -30,6 +31,7 @@ export const initialState = {
 const rolesReducer = (state = initialState, action) => {
   switch (action.type) {
     case APOLLO_MUTATION_ERROR:
+      markBranchHit("rolesReducer", 0);
       return Object.assign({}, state, {
         snackbarOptions: {
           isOpen: true,
@@ -39,6 +41,7 @@ const rolesReducer = (state = initialState, action) => {
       });
 
     case OPENED_SNACKBAR:
+      markBranchHit("rolesReducer", 1);
       return Object.assign({}, state, {
         snackbarOptions: {
           isOpen: true,
@@ -48,9 +51,11 @@ const rolesReducer = (state = initialState, action) => {
       });
 
     case DISMISSED_SNACKBAR:
+      markBranchHit("rolesReducer", 2);
       return Object.assign({}, state, { snackbarOptions: { isOpen: false } });
-
+      
     default:
+      markBranchHit("rolesReducer", 3);
       return state;
   }
 };

--- a/src/test/reducers/selectors.spec.js
+++ b/src/test/reducers/selectors.spec.js
@@ -1,0 +1,48 @@
+import { selectKeyValuesDataSource } from '../../reducers/selectors';
+
+describe('selectKeyValuesDataSource', () => {
+  it('should return an empty array when keyValuesOrigin is undefined', () => {
+    const result = selectKeyValuesDataSource(undefined, {});
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty array when keyValuesOrigin does not have type', () => {
+    const result = selectKeyValuesDataSource({}, {});
+    expect(result).toEqual([]);
+  });
+
+  it('should return stopPlace keyValues when keyValuesOrigin.type is "stopPlace"', () => {
+    const keyValuesOrigin = { type: 'stopPlace' };
+    const stopPlace = { keyValues: ['a', 'b', 'c'] };
+    const result = selectKeyValuesDataSource(keyValuesOrigin, stopPlace);
+    expect(result).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should return quay keyValues when keyValuesOrigin.type is "quay"', () => {
+    const keyValuesOrigin = { type: 'quay', index: 0 };
+    const stopPlace = { quays: [{ keyValues: ['a', 'b'] }, { keyValues: ['c', 'd'] }, { keyValues: ['e', 'f'] }] };
+    const result = selectKeyValuesDataSource(keyValuesOrigin, stopPlace);
+    expect(result).toEqual(['a', 'b']);
+  });
+
+  it('should return an empty array when keyValuesOrigin.type is "quay" and index is out of bounds', () => {
+    const keyValuesOrigin = { type: 'quay', index: 100 };
+    const stopPlace = { quays: [{ keyValues: ['a', 'b'] }, { keyValues: ['c', 'd'] }, { keyValues: ['e', 'f'] }] };
+    const result = selectKeyValuesDataSource(keyValuesOrigin, stopPlace);
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty array when keyValuesOrigin.type is "OTHER"', () => {
+    const keyValuesOrigin = { type: 'OTHER', index: 0 };
+    const stopPlace = { quays: [{ keyValues: ['a', 'b'] }, { keyValues: ['c', 'd'] }, { keyValues: ['e', 'f'] }] };
+    const result = selectKeyValuesDataSource(keyValuesOrigin, stopPlace);
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty array when keyValuesOrigin.type is unsupported', () => {
+    const keyValuesOrigin = { type: null };
+    const stopPlace = { keyValues: ['key1', 'key2'] };
+    const result = selectKeyValuesDataSource(keyValuesOrigin, stopPlace);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/test/reducers/snackbarReducer.spec.js
+++ b/src/test/reducers/snackbarReducer.spec.js
@@ -1,4 +1,4 @@
-import rolesReducer, { initialState, getErrorMsg } from '../../reducers/snackbarReducer';
+import rolesReducer, { initialState } from '../../reducers/snackbarReducer';
 import {
   APOLLO_MUTATION_ERROR,
   ERROR,

--- a/src/test/reducers/snackbarReducer.spec.js
+++ b/src/test/reducers/snackbarReducer.spec.js
@@ -1,0 +1,86 @@
+import rolesReducer, { initialState, getErrorMsg } from '../../reducers/snackbarReducer';
+import {
+  APOLLO_MUTATION_ERROR,
+  ERROR,
+  OPENED_SNACKBAR,
+  DISMISSED_SNACKBAR,
+} from '../../actions/Types';
+
+describe('rolesReducer', () => {
+  it('should return the initial state when state is undefined', () => {
+    expect(rolesReducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should return initial state for an unknown action type', () => {
+    const action = {
+      type: 'UNKNOWN_ACTION',
+    };
+    expect(rolesReducer(initialState, action)).toEqual(initialState);
+  });
+
+  it('should handle APOLLO_MUTATION_ERROR', () => {
+    const action = {
+      type: APOLLO_MUTATION_ERROR,
+      error: [{ message: 'Error' }],
+    };
+    const expectedState = {
+      snackbarOptions: {
+        isOpen: true,
+        status: ERROR,
+        errorMsg: 'Error',
+      },
+    };
+    expect(rolesReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle APOLLO_MUTATION_ERROR with null error', () => {
+    const action = {
+      type: APOLLO_MUTATION_ERROR,
+      error: null,
+    };
+    const expectedState = {
+      snackbarOptions: {
+        isOpen: true,
+        status: ERROR,
+        errorMsg: null,
+      },
+    };
+    expect(rolesReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle OPENED_SNACKBAR', () => {
+    const action = {
+      type: OPENED_SNACKBAR,
+      payload: {
+        status: 'Success',
+      },
+    };
+    const expectedState = {
+      snackbarOptions: {
+        isOpen: true,
+        status: 'Success',
+        errorMsg: null,
+      },
+    };
+    expect(rolesReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should handle DISMISSED_SNACKBAR', () => {
+    const initialStateWithOpenSnackbar = {
+      snackbarOptions: {
+        isOpen: true,
+        message: 'This is a short message',
+        status: 'Success',
+      },
+    };
+    const action = {
+      type: DISMISSED_SNACKBAR,
+    };
+    const expectedState = {
+      snackbarOptions: {
+        isOpen: false,
+      },
+    };
+    expect(rolesReducer(initialStateWithOpenSnackbar, action)).toEqual(expectedState);
+  });
+});


### PR DESCRIPTION
# Custom Measurement 
<img width="521" alt="image" src="https://github.com/OwlSurojit/abzu/assets/39962750/de174a18-6397-4e93-96df-d1f7b72a32ab">

# Jest Coverage
## Selectors
<img width="647" alt="image" src="https://github.com/OwlSurojit/abzu/assets/39962750/199a09ed-ac91-4298-bb87-6aafb2506c49">

`npm run test -- --coverage --collectCoverageFrom=src/reducers/selectors.js --watchAll`


## Snackbar Reducer
<img width="699" alt="image" src="https://github.com/OwlSurojit/abzu/assets/39962750/4d1e4e42-bd9e-4f9d-9d7a-1258d8208622">

`npm run test -- --coverage --collectCoverageFrom=src/reducers/snackbarReducer.js --watchAll`